### PR TITLE
Upgrade random_string to ^2.1.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   meta: ^1.1.6
   basic_utils: ^2.5.4
   http: ^0.12.1
-  random_string: ^2.0.1
+  random_string: ^2.1.0
 
 dev_dependencies:
   test: ^1.0.0


### PR DESCRIPTION
This pull request simply upgrades the version of `random_string` to ^2.1.0.  Previous versions had a mistake in how randomBetween was implemented.